### PR TITLE
Revert "Bump highlight.js from 9.17.1 to 9.18.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1230,10 +1230,13 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.18.5",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.5.tgz",
-      "integrity": "sha512-a5bFyofd/BHCX52/8i8uJkjr9DYwXIPnM/plwI6W7ezItLGqzt7X2G2nXuYSfsIJdkwwj/g9DG1LkcGJI/dDoA==",
-      "dev": true
+      "version": "9.17.1",
+      "resolved": "http://localhost:8081/repository/npm/highlight.js/-/highlight.js-9.17.1.tgz",
+      "integrity": "sha512-TA2/doAur5Ol8+iM3Ov7qy3jYcr/QiJ2eDTdRF4dfbjG7AaaB99J5G+zSl11ljbl6cIcahgPY6SKb3sC3EJ0fw==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.5.3"
+      }
     },
     "hoek": {
       "version": "4.2.1",


### PR DESCRIPTION
Reverts dooleydiligent/unit-redis-ness#31