### PR TITLE
fix: Allow host and port to be specified

### DIFF
--- a/src/server/resp-server.ts
+++ b/src/server/resp-server.ts
@@ -32,10 +32,10 @@ export class RespServer extends EventEmitter {
   private logger: Logger = new Logger(module.id);
   private server: net.Server = net.createServer();
   private serverContext: IServerContext;
-  constructor() {
+  constructor(hostArg?: string, portArg?: number) {
     super();
-    const host = RespServer.DEFAULT_HOST;
-    const port = Number(RespServer.DEFAULT_PORT);
+    const host = hostArg || RespServer.DEFAULT_HOST;
+    const port = portArg || Number(RespServer.DEFAULT_PORT);
     const commandSuite = new CommandSuite();
     this.serverContext = new RespServerContext(host, port, commandSuite);
   }


### PR DESCRIPTION
If I define a env var `REDIS_PORT=1234` and put a breakpoint on line 37 I can see `process.env.REDIS_PORT` equals `1234` but `DEFAULT_PORT` is `6397` so the port is not actually set.

This change allows it to be set via optional constructor args. 

I'm not sure anyone can specify a non-default port at the moment, but just in case, my change doesn't affect existing behaviour.